### PR TITLE
Run plugin also during testOnly task

### DIFF
--- a/src/main/scala/RedisPlugin.scala
+++ b/src/main/scala/RedisPlugin.scala
@@ -29,6 +29,11 @@ object RedisPlugin extends AutoPlugin {
       val t = (test in Test).dependsOn(startRedis)
 
       t.andFinally(RedisUtils.stopRedisInstances())
+    },
+    (testOnly in Test) <<= {
+      val t = (testOnly in Test).dependsOn(startRedis)
+
+      t.andFinally(RedisUtils.stopRedisInstances())
     }
   )
 


### PR DESCRIPTION
Hi Francois! TestOnly is used to run a subset of tests. We should start Redis during this task too.
